### PR TITLE
Removed asterix from inflection

### DIFF
--- a/eng
+++ b/eng
@@ -1,3 +1,4 @@
+
 3rd	3rded	V;PST
 3rd	3rded	V;V.PTCP;PST
 3rd	3rding	V;V.PTCP;PRS

--- a/eng
+++ b/eng
@@ -1,4 +1,3 @@
-
 3rd	3rded	V;PST
 3rd	3rded	V;V.PTCP;PST
 3rd	3rding	V;V.PTCP;PRS
@@ -5562,10 +5561,10 @@ awhape	awhaped	V;V.PTCP;PST
 awhape	awhapes	V;3;SG;PRS
 awhape	awhape	V;NFIN
 awhape	awhaping	V;V.PTCP;PRS
-awrath	*awrathed	V;PST
+awrath	awrathed	V;PST
 awrath	awrathed	V;V.PTCP;PST
-awrath	*awrathing	V;V.PTCP;PRS
-awrath	*awraths	V;3;SG;PRS
+awrath	awrathing	V;V.PTCP;PRS
+awrath	awraths	V;3;SG;PRS
 awrath	awrath	V;NFIN
 awroth	awrothed	V;PST
 awroth	awrothed	V;V.PTCP;PST
@@ -19026,7 +19025,7 @@ conflict	conflicts	V;3;SG;PRS
 conflict	conflict	V;NFIN
 confœderate	confœderated	V;PST
 confœderate	confœderated	V;V.PTCP;PST
-confœderate	*confœderates	V;3;SG;PRS
+confœderate	confœderates	V;3;SG;PRS
 confœderate	confœderate	V;NFIN
 confœderate	confœderating	V;V.PTCP;PRS
 conform	conformed	V;PST
@@ -20532,9 +20531,9 @@ counter-attack	counter-attacks	V;3;SG;PRS
 counterattack	counterattacks	V;3;SG;PRS
 counter-attack	counter-attack	V;NFIN
 counterattack	counterattack	V;NFIN
-counterattract	*counterattracted	V;PST
+counterattract	counterattracted	V;PST
 counterattract	counterattracted	V;V.PTCP;PST
-counterattract	*counterattracting	V;V.PTCP;PRS
+counterattract	counterattracting	V;V.PTCP;PRS
 counterattract	counterattracts	V;3;SG;PRS
 counterattract	counterattract	V;NFIN
 counterbalance	counterbalanced	V;PST
@@ -32440,10 +32439,10 @@ dynamize	dynamize	V;NFIN
 dynamize	dynamizing	V;V.PTCP;PRS
 dyscrasy	dyscrasied	V;PST
 dyscrasy	dyscrasied	V;V.PTCP;PST
-dyscrasy	*dyscrasies	V;3;SG;PRS
+dyscrasy	dyscrasies	V;3;SG;PRS
 dyscrasy	dyscrasyed	V;PST
 dyscrasy	dyscrasyed	V;V.PTCP;PST
-dyscrasy	*dyscrasying	V;V.PTCP;PRS
+dyscrasy	dyscrasying	V;V.PTCP;PRS
 dyscrasy	dyscrasy	V;NFIN
 dyslexify	dyslexified	V;PST
 dyslexify	dyslexified	V;V.PTCP;PST
@@ -38095,9 +38094,9 @@ fake	fakes	V;3;SG;PRS
 fake	fake	V;NFIN
 fake	faking	V;V.PTCP;PRS
 falchion	falchioned	V;PST
-falchion	*falchioned	V;V.PTCP;PST
-falchion	*falchioning	V;V.PTCP;PRS
-falchion	*falchions	V;3;SG;PRS
+falchion	falchioned	V;V.PTCP;PST
+falchion	falchioning	V;V.PTCP;PRS
+falchion	falchions	V;3;SG;PRS
 falchion	falchion	V;NFIN
 falcon	falconed	V;PST
 falcon	falconed	V;V.PTCP;PST
@@ -51061,13 +51060,13 @@ indignify	indignified	V;V.PTCP;PST
 indignify	indignifies	V;3;SG;PRS
 indignify	indignifying	V;V.PTCP;PRS
 indignify	indignify	V;NFIN
-ind.	*ind'd	V;PST
-ind.	*ind'd	V;V.PTCP;PST
-ind.	*inded	V;PST
-ind.	*inded	V;V.PTCP;PST
-ind.	*inding	V;V.PTCP;PRS
-ind.	*ind's	V;3;SG;PRS
-ind.	*inds	V;3;SG;PRS
+ind.	ind'd	V;PST
+ind.	ind'd	V;V.PTCP;PST
+ind.	inded	V;PST
+ind.	inded	V;V.PTCP;PST
+ind.	inding	V;V.PTCP;PRS
+ind.	ind's	V;3;SG;PRS
+ind.	inds	V;3;SG;PRS
 ind.	ind.	V;NFIN
 indispose	indisposed	V;PST
 indispose	indisposed	V;V.PTCP;PST
@@ -56063,9 +56062,9 @@ latinize	latinize	V;NFIN
 Latinize	Latinize	V;NFIN
 latinize	latinizing	V;V.PTCP;PRS
 Latinize	Latinizing	V;V.PTCP;PRS
-latrate	*latrated	V;PST
-latrate	*latrated	V;V.PTCP;PST
-latrate	*latrates	V;3;SG;PRS
+latrate	latrated	V;PST
+latrate	latrated	V;V.PTCP;PST
+latrate	latrates	V;3;SG;PRS
 latrate	latrate	V;NFIN
 latrate	latrating	V;V.PTCP;PRS
 lattice	latticed	V;PST
@@ -75075,7 +75074,7 @@ prælude	prælude	V;NFIN
 prælude	præluding	V;V.PTCP;PRS
 præmise	præmised	V;PST
 præmise	præmised	V;V.PTCP;PST
-præmise	*præmises	V;3;SG;PRS
+præmise	præmises	V;3;SG;PRS
 præmise	præmise	V;NFIN
 præmise	præmising	V;V.PTCP;PRS
 praemunire	praemunired	V;PST
@@ -78264,7 +78263,7 @@ quæry	quæry	V;NFIN
 quæstion	quæstioned	V;PST
 quæstion	quæstioned	V;V.PTCP;PST
 quæstion	quæstioning	V;V.PTCP;PRS
-quæstion	*quæstions	V;3;SG;PRS
+quæstion	quæstions	V;3;SG;PRS
 quæstion	quæstion	V;NFIN
 quaff	quaffed	V;PST
 quaff	quaffed	V;V.PTCP;PST
@@ -100463,7 +100462,7 @@ syllabicate	syllabicate	V;NFIN
 syllabicate	syllabicating	V;V.PTCP;PRS
 syllabificate	syllabificated	V;PST
 syllabificate	syllabificated	V;V.PTCP;PST
-syllabificate	*syllabificates	V;3;SG;PRS
+syllabificate	syllabificates	V;3;SG;PRS
 syllabificate	syllabificate	V;NFIN
 syllabificate	syllabificating	V;V.PTCP;PRS
 syllabify	syllabified	V;PST


### PR DESCRIPTION
Some of the english inflected forms begin with an asterix. 

Typically, asterix would indicate that the inflection is not possible. But I don't know if the same convention is used for this data, or if this is simply a scraping error.  